### PR TITLE
CA-140545: Cause child fe to exit after client calls dontwaitpid

### DIFF
--- a/lib/fe.ml
+++ b/lib/fe.ml
@@ -26,5 +26,6 @@ and ferpc =
     | Execed of int
     | Finished of process_result
     | Log_reopen
+    | Dontwaitpid
 with rpc
 


### PR DESCRIPTION
Once the required command has been forked, instead of making a blocking
waitpid call to catch the command's exit, we now first make a
nonblocking call to check that the command is still running, and then
set up a signal handler to catch SIGCHLD and report the command's exit
code. This is all done with SIGCHLD temporarily blocked to avoid a race.

Once the signal handler is set up, the main thread waits for the client
to send the new Dontwaitpid command over the socket - once received, the
child fe knows that the command's exit code is no longer needed by the
client, and thus fe can exit. The command will continue to run in the
background, if it is still running.
