### PR TITLE
CA-188814: use negative rather than infinite timout

### DIFF
--- a/lib/forkhelpers.ml
+++ b/lib/forkhelpers.ml
@@ -168,7 +168,7 @@ let safe_close_and_exec ?env stdin stdout stderr (fds: (string * Unix.file_descr
     close_fds
 
 
-let execute_command_get_output_inner ?env ?stdin ?(syslog_stdout=NoSyslogging) ?(timeout=infinity) cmd args =
+let execute_command_get_output_inner ?env ?stdin ?(syslog_stdout=NoSyslogging) ?(timeout=(-1.0)) cmd args =
 	let to_close = ref [] in
 	let close fd =
 		if List.mem fd !to_close then begin

--- a/test/fe_test.ml
+++ b/test/fe_test.ml
@@ -84,9 +84,20 @@ let test_delay () =
   | e ->
     failwith (Printf.sprintf "Failed with unexpected exception: %s" (Printexc.to_string e))
 
+let test_notimeout () =
+  let exe = Printf.sprintf "/proc/%d/exe" (Unix.getpid()) in
+  let args = ["sleep"] in
+  try
+    Forkhelpers.execute_command_get_output exe args;
+    ()
+  with
+  | e ->
+    failwith (Printf.sprintf "Failed with unexpected exception: %s" (Printexc.to_string e))
+
 
 let master () = 
   test_delay ();
+  test_notimeout ();
   Printf.printf "\nCompleted timeout test\n";
   let combinations = shuffle (all_combinations ()) in
   Printf.printf "Starting %d tests\n" (List.length combinations);


### PR DESCRIPTION
OCaml maps negative timeout vals to unbounded wait rather than
infinite timeout. Also add a test that exercises the default
timeout of the select.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>