### PR TITLE
CP-17694: Log stdout/stderr from device model

### DIFF
--- a/lib/fe.ml
+++ b/lib/fe.ml
@@ -8,6 +8,7 @@ and setup_cmd = {
   env : string list;
   id_to_fd_map : (string * int option) list;
   syslog_stdout : syslog_stdout_t;
+  redirect_stderr_to_stdout : bool;
 } 
 
 and setup_response = {

--- a/lib/forkhelpers.ml
+++ b/lib/forkhelpers.ml
@@ -100,7 +100,7 @@ type syslog_stdout_t =
 
 (** Safe function which forks a command, closing all fds except a whitelist and
     having performed some fd operations in the child *)
-let safe_close_and_exec ?env stdin stdout stderr (fds: (string * Unix.file_descr) list) ?(syslog_stdout=NoSyslogging)
+let safe_close_and_exec ?env stdin stdout stderr (fds: (string * Unix.file_descr) list) ?(syslog_stdout=NoSyslogging) ?(redirect_stderr_to_stdout = false)
     (cmd: string) (args: string list) =
 
   let sock = Fecomms.open_unix_domain_sock_client "/var/xapi/forker/main" in
@@ -142,7 +142,7 @@ let safe_close_and_exec ?env stdin stdout stderr (fds: (string * Unix.file_descr
       | Syslog_DefaultKey -> {Fe.enabled=true; Fe.key=None}
       | Syslog_WithKey k -> {Fe.enabled=true; Fe.key=Some k}
     in
-    Fecomms.write_raw_rpc sock (Fe.Setup {Fe.cmdargs=(cmd::args); env=(Array.to_list env); id_to_fd_map = id_to_fd_map; syslog_stdout = syslog_stdout});
+    Fecomms.write_raw_rpc sock (Fe.Setup {Fe.cmdargs=(cmd::args); env=(Array.to_list env); id_to_fd_map = id_to_fd_map; syslog_stdout = syslog_stdout; redirect_stderr_to_stdout = redirect_stderr_to_stdout});
 
     let response = Fecomms.read_raw_rpc sock in
 

--- a/lib/forkhelpers.mli
+++ b/lib/forkhelpers.mli
@@ -76,7 +76,7 @@ exception Subprocess_timeout
 	with the optional [stdin], [stdout] and [stderr] file descriptors (or /dev/null if not
 	specified) and with any key from [id_to_fd_list] in [args] replaced by the integer
 	value of the file descriptor in the final process. *)
-val safe_close_and_exec : ?env:string array -> Unix.file_descr option -> Unix.file_descr option -> Unix.file_descr option -> (string * Unix.file_descr) list -> ?syslog_stdout:syslog_stdout_t -> string -> string list -> pidty
+val safe_close_and_exec : ?env:string array -> Unix.file_descr option -> Unix.file_descr option -> Unix.file_descr option -> (string * Unix.file_descr) list -> ?syslog_stdout:syslog_stdout_t -> ?redirect_stderr_to_stdout: bool -> string -> string list -> pidty
 
 (** [waitpid p] returns the (pid, Unix.process_status) *)
 val waitpid : pidty -> (int * Unix.process_status)

--- a/src/child.ml
+++ b/src/child.ml
@@ -15,6 +15,7 @@ type state_t = {
 	env : string list;
 	id_to_fd_map : (string * int option) list;
 	syslog_stdout : syslog_stdout_t;
+	redirect_stderr_to_stdout : bool;
 	ids_received : (string * Unix.file_descr) list;
 	fd_sock2 : Unix.file_descr option;
 	finished : bool;
@@ -189,6 +190,8 @@ let run state comms_sock fd_sock fd_sock_path =
 
 			(* Make the child's stdout go into the pipe *)
 			Opt.iter (fun out_fd -> Unix.dup2 out_fd Unix.stdout) !out_childlogging;
+			if state.redirect_stderr_to_stdout then
+				Opt.iter (fun out_fd -> Unix.dup2 out_fd Unix.stderr) !out_childlogging;
 
 			(* Now let's close everything except those fds mentioned in the ids_received list *)
 			Unixext.close_all_fds_except ([Unix.stdin; Unix.stdout; Unix.stderr] @ fds);

--- a/src/fe_main.ml
+++ b/src/fe_main.ml
@@ -4,7 +4,7 @@ let default_pidfile = "/var/run/fe.pid"
 
 open Fe_debug
 
-let setup sock cmdargs id_to_fd_map syslog_stdout env =
+let setup sock cmdargs id_to_fd_map syslog_stdout redirect_stderr_to_stdout env =
   let fd_sock_path = Printf.sprintf "/var/xapi/forker/fd_%s" 
     (Uuidm.to_string (Uuidm.create `V4)) in
   let fd_sock = Fecomms.open_unix_domain_sock () in
@@ -26,6 +26,7 @@ let setup sock cmdargs id_to_fd_map syslog_stdout env =
 	env=env;
 	id_to_fd_map=id_to_fd_map; 
 	syslog_stdout={Child.enabled=syslog_stdout.Fe.enabled; Child.key=syslog_stdout.Fe.key};
+	redirect_stderr_to_stdout = redirect_stderr_to_stdout;
 	ids_received=[];
 	fd_sock2=None;
 	finished=false;
@@ -71,7 +72,7 @@ let _ =
       let cmd = Fecomms.read_raw_rpc sock in
       match cmd with
 	| Fe.Setup s ->
-	    let result = setup sock s.Fe.cmdargs s.Fe.id_to_fd_map s.Fe.syslog_stdout s.Fe.env in
+	    let result = setup sock s.Fe.cmdargs s.Fe.id_to_fd_map s.Fe.syslog_stdout s.Fe.redirect_stderr_to_stdout s.Fe.env in
 	    (match result with
 	      | Some response ->
 		  Fecomms.write_raw_rpc sock (Fe.Setup_response response);


### PR DESCRIPTION
Currently, Forkhelpers dones't support to log stderr,
this change adds optional boolean parameter 'syslog_stderr_enable' when call Forkhelpers.safe_close_and_exec.

stderr shares the same 'log key' and 'pipe fd' with stdout.

eg:
1. Before this change, usecase of Forkhelper.safe_close_and_exec:

let syslog_stdout = Forkhelpers.Syslog_WithKey "stdout_tag" in
Forkhelpers.execute_command_get_output ~syslog_stdout cmd args

2. After this change, usecase of Forkhelper.safe_close_and_exec:

let syslog_stdout = Forkhelpers.Syslog_WithKey "stdout_tag" in
let syslog_stderr_enable = true in
Forkhelpers.execute_command_get_output ~syslog_stdout ~syslog_stderr_enable  cmd args

Signed-off-by: Liang Dai <liang.dai1@citrix.com>