### PR TITLE
CP-17694: Log stdout/stderr from device model

### DIFF
--- a/lib/fe.ml
+++ b/lib/fe.ml
@@ -1,4 +1,4 @@
-type syslog_stdout_t = {
+type syslog_std_t = {
   enabled : bool;
   key : string option;
 }
@@ -7,7 +7,8 @@ and setup_cmd = {
   cmdargs : string list;
   env : string list;
   id_to_fd_map : (string * int option) list;
-  syslog_stdout : syslog_stdout_t;
+  syslog_stdout : syslog_std_t;
+  syslog_stderr : syslog_std_t;
 } 
 
 and setup_response = {

--- a/lib/forkhelpers.mli
+++ b/lib/forkhelpers.mli
@@ -34,7 +34,7 @@
 
 (** {2 High-level interface } *)
 
-type syslog_stdout_t =
+type syslog_std_t =
   | NoSyslogging
   | Syslog_DefaultKey
   | Syslog_WithKey of string
@@ -42,12 +42,12 @@ type syslog_stdout_t =
 (** [execute_command_get_output cmd args] runs [cmd args] and returns (stdout, stderr)
 	on success (exit 0). On failure this raises 
     [Spawn_internal_error(stderr, stdout, Unix.process_status)] *)
-val execute_command_get_output : ?env:string array -> ?syslog_stdout:syslog_stdout_t -> ?timeout:float -> string -> string list -> string * string
+val execute_command_get_output : ?env:string array -> ?syslog_stdout:syslog_std_t -> ?timeout:float -> string -> string list -> string * string
 
 (** [execute_command_get_output cmd args stdin] runs [cmd args], passes in the string [stdin] and returns (stdout, stderr)
 	on success (exit 0). On failure this raises 
     [Spawn_internal_error(stderr, stdout, Unix.process_status)] *)
-val execute_command_get_output_send_stdin : ?env:string array -> ?syslog_stdout:syslog_stdout_t -> ?timeout:float -> string -> string list -> string -> string * string
+val execute_command_get_output_send_stdin : ?env:string array -> ?syslog_stdout:syslog_std_t -> ?timeout:float -> string -> string list -> string -> string * string
 
 (** Thrown by [execute_command_get_output] if the subprocess exits with a non-zero exit code *)
 exception Spawn_internal_error of string * string * Unix.process_status
@@ -76,7 +76,7 @@ exception Subprocess_timeout
 	with the optional [stdin], [stdout] and [stderr] file descriptors (or /dev/null if not
 	specified) and with any key from [id_to_fd_list] in [args] replaced by the integer
 	value of the file descriptor in the final process. *)
-val safe_close_and_exec : ?env:string array -> Unix.file_descr option -> Unix.file_descr option -> Unix.file_descr option -> (string * Unix.file_descr) list -> ?syslog_stdout:syslog_stdout_t -> string -> string list -> pidty
+val safe_close_and_exec : ?env:string array -> Unix.file_descr option -> Unix.file_descr option -> Unix.file_descr option -> (string * Unix.file_descr) list -> ?syslog_stdout:syslog_std_t -> ?syslog_stderr:syslog_std_t -> string -> string list -> pidty
 
 (** [waitpid p] returns the (pid, Unix.process_status) *)
 val waitpid : pidty -> (int * Unix.process_status)

--- a/src/fe_main.ml
+++ b/src/fe_main.ml
@@ -4,7 +4,7 @@ let default_pidfile = "/var/run/fe.pid"
 
 open Fe_debug
 
-let setup sock cmdargs id_to_fd_map syslog_stdout env =
+let setup sock cmdargs id_to_fd_map syslog_stdout syslog_stderr env =
   let fd_sock_path = Printf.sprintf "/var/xapi/forker/fd_%s" 
     (Uuidm.to_string (Uuidm.create `V4)) in
   let fd_sock = Fecomms.open_unix_domain_sock () in
@@ -26,6 +26,7 @@ let setup sock cmdargs id_to_fd_map syslog_stdout env =
 	env=env;
 	id_to_fd_map=id_to_fd_map; 
 	syslog_stdout={Child.enabled=syslog_stdout.Fe.enabled; Child.key=syslog_stdout.Fe.key};
+	syslog_stderr={Child.enabled=syslog_stderr.Fe.enabled; Child.key=syslog_stderr.Fe.key};
 	ids_received=[];
 	fd_sock2=None;
 	finished=false;
@@ -71,7 +72,7 @@ let _ =
       let cmd = Fecomms.read_raw_rpc sock in
       match cmd with
 	| Fe.Setup s ->
-	    let result = setup sock s.Fe.cmdargs s.Fe.id_to_fd_map s.Fe.syslog_stdout s.Fe.env in
+	    let result = setup sock s.Fe.cmdargs s.Fe.id_to_fd_map s.Fe.syslog_stdout s.Fe.syslog_stderr s.Fe.env in
 	    (match result with
 	      | Some response ->
 		  Fecomms.write_raw_rpc sock (Fe.Setup_response response);


### PR DESCRIPTION
Currently, Forkhelpers dones't support to log stderr,
this change adds log stderr support.

create two pipes in child process and use 'select' to process each fd.

eg:
1. Before this change, usecase of Forkhelper.safe_close_and_exec:

let syslog_stdout = Forkhelpers.Syslog_WithKey "stdout_tag" in
Forkhelpers.execute_command_get_output ~syslog_stdout cmd args

2. After this change, usecase of Forkhelper.safe_close_and_exec:

let syslog_stdout = Forkhelpers.Syslog_WithKey "stdout_tag" in
let syslog_stderr = Forkhelpers.Syslog_WithKey "stderr_tag" in
Forkhelpers.execute_command_get_output ~syslog_stdout ~syslog_stderr cmd args

Signed-off-by: Liang Dai <liang.dai1@citrix.com>