### PR TITLE
.travis.yml: run "oasis setup" before "make"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ env:
     global:
         - REPO_PACKAGE_NAME=forkexecd
         - REPO_CONFIGURE_CMD=true
-        - REPO_BUILD_CMD=make
+        - REPO_BUILD_CMD='oasis setup && make'
         - REPO_TEST_CMD='sudo make test'


### PR DESCRIPTION
To generate the Makefile with the DevFiles OASIS plugin before running
make.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>