### PR TITLE
jbuilder runtest: fix running sudo test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ env:
         - REPO_PACKAGE_NAME=forkexecd
         - REPO_CONFIGURE_CMD=true
         - REPO_BUILD_CMD='make'
-        - REPO_TEST_CMD='make test || (cd _build/default/test && sudo ./fe_test.sh)'
+        - REPO_TEST_CMD='make test'

--- a/test/fe_test.sh
+++ b/test/fe_test.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 
 ../src/fe_main.exe &
+for x in `seq 1 10`; do
+	test -S /var/xapi/forker/main || sleep 1
+done
 ./fe_test.exe 16

--- a/test/jbuild
+++ b/test/jbuild
@@ -10,5 +10,5 @@
  ((name runtest)
   (package xapi-forkexecd)
   (deps (fe_test.sh fe_test.exe ../src/fe_main.exe))
-  (action (run sudo ./${<}))
+  (action (bash "sudo ./fe_test.sh"))
   ))


### PR DESCRIPTION
I was not able to run this locally, it was failing with:
Error: exception Sys_error("/usr/bin/sudo: Permission denied")

With this change it runs:
```
[planex:trm forkexecd]$ make test
jbuilder runtest
Entering directory '/build/local/repos'
        bash alias forkexecd/test/runtest
Caught timeout exception after 4.008846 seconds

Completed timeout test
Starting 540 tests
  540 100 ######################################################################
Completed 540 tests
```