### PR TITLE
Add fe_argv module for incrementally building argv

### DIFF
--- a/lib/fe_argv.ml
+++ b/lib/fe_argv.ml
@@ -55,4 +55,8 @@ module Add = struct
   let file_descr uuid fd =
     fun s -> (), { s with fds = (uuid, fd) :: s.fds }
 
+  let optional f = function
+    | None   -> return ()
+    | Some x -> many (f x)
+
 end

--- a/lib/fe_argv.ml
+++ b/lib/fe_argv.ml
@@ -1,0 +1,58 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+
+(* state that we incrementally change *)
+type argv =
+  { argv: string list                       (** command line in rev order *)
+  ; fds:  (string * Unix.file_descr) list   (** open files *)
+  }
+
+
+  (* This is a state monad *)
+type 'a t = argv -> 'a * argv
+
+let return x = fun s -> x, s
+let bind m f = fun s -> match m s with x, s' -> f x s'
+let (>>=)    = bind
+
+let empty =
+  { argv = []
+  ; fds  = []
+  }
+
+let run t       = t empty
+let argv   argv = List.rev argv.argv
+let fd_map argv = argv.fds
+
+module Add = struct
+
+  let arg x =
+    fun s -> (), { s with argv = x :: s.argv }
+
+  let many xs =
+    fun s -> (), { s with argv = List.rev xs @ s.argv }
+
+  let each f xs =
+    xs |> List.map f |> List.concat |> many
+
+  let fmt fmt =
+    Printf.kprintf
+      (fun str -> fun s -> (), { s with argv = str :: s.argv })
+      fmt
+
+  let file_descr uuid fd =
+    fun s -> (), { s with fds = (uuid, fd) :: s.fds }
+
+end

--- a/lib/fe_argv.mli
+++ b/lib/fe_argv.mli
@@ -1,0 +1,54 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(** This module supports building a large command line (argument) vector
+ * incrementally in a monad.
+ *)
+
+type argv
+type 'a t      (** monad, holding current command line *)
+
+(** basic functions to construct a [t] value. More below *)
+val return: 'a -> 'a t
+val bind:   'a t -> ('a -> 'b t) -> 'b t
+
+(** turn a [t] value into something useful, containing the values
+ * we are interested in. These can be accessed using [argv] and [fd_map].
+ *)
+val run:    'a t -> 'a * argv
+val argv:   argv -> string list                     (** argument list *)
+val fd_map: argv -> (string * Unix.file_descr) list (** file descriptors *)
+
+(** functions to build argument vector incrementally *)
+
+module Add: sig
+  val arg: string -> unit t
+  (** add single string to argv *)
+
+  val many: string list -> unit t
+  (** add list of strings to argv *)
+
+  val each: ('a -> string list) -> 'a list -> unit t
+  (** expand a list of values to strings, which are added to argv *)
+
+  val fmt: ('a, unit, string, argv -> unit * argv) format4 -> 'a
+  (* like [add] but takes printf-like arguments: ["%d-%d" 4 5] *)
+
+  val file_descr: string -> Unix.file_descr -> unit t
+  (** add a file descriptor under a name. Forkexecd will replace the
+   * name in the argument vector with the integer of the file descriptor
+   * *)
+end
+
+

--- a/lib/fe_argv.mli
+++ b/lib/fe_argv.mli
@@ -43,7 +43,11 @@ module Add: sig
   (** expand a list of values to strings, which are added to argv *)
 
   val fmt: ('a, unit, string, argv -> unit * argv) format4 -> 'a
-  (* like [add] but takes printf-like arguments: ["%d-%d" 4 5] *)
+  (** like [add] but takes printf-like arguments: ["%d-%d" 4 5] *)
+
+  val optional: ('a -> string list) -> 'a option -> unit t
+  (** [optional f arg] applies [f] to [Some arg] to produce arguments.
+   * If [arg] is [None], no arguments are added *)
 
   val file_descr: string -> Unix.file_descr -> unit t
   (** add a file descriptor under a name. Forkexecd will replace the


### PR DESCRIPTION
Module fe_argv helps to build a command line incrementally in a monadic
way. This is most useful when a process to be started with forkexed
requires a long and complicated list of arguments and/or is passed file
descriptors.

This is a purely auxiliary module - it does not interact with the
existing code directly.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>