### PR TITLE
Simplify lib/jbuild

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,36 +1,16 @@
-(* -*- tuareg -*- *)
-#require "unix"
+(jbuild_version 1)
 
-let flags = function
-  | [] -> ""
-  | pkgs ->
-    let cmd = "ocamlfind ocamlc -verbose" ^ (
-        List.fold_left (fun acc pkg -> acc ^ " -package " ^ pkg) "" pkgs
-      ) in
-    let ic = Unix.open_process_in
-        (cmd ^ " | grep -oEe '-ppx (\"([^\"\\]|\\.)+\"|\\w+)'")
-    in
-    let rec go ic acc =
-      try go ic (acc ^ " " ^ input_line ic) with End_of_file -> close_in ic; acc
-    in
-    go ic ""
-
-let rewriters = ["ppx_deriving_rpc"]
-let flags = flags rewriters
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
  ((name forkexec)
   (public_name forkexec)
   (wrapped false)
-  (flags (:standard %s))
+  (flags (:standard))
   (libraries (fd-send-recv
-              rpclib.json
-              threads
-              uuidm
-              xapi-stdext-monadic
-              xapi-stdext-pervasives
-              xapi-stdext-unix
-              xcp))
- ))
-|} flags
+               rpclib.json
+               threads
+               uuidm
+               xapi-stdext-monadic
+               xapi-stdext-pervasives
+               xapi-stdext-unix
+               xcp))
+  (preprocess (pps (ppx_deriving_rpc)))))


### PR DESCRIPTION
Running ppx_deriving_rpc no longer requires generating code.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>