### PR TITLE
CP-29470: Use a path on tmpfs for temporary sockets and files

### DIFF
--- a/lib/forkhelpers.ml
+++ b/lib/forkhelpers.ml
@@ -70,11 +70,13 @@ let getpid (_sock, pid) = pid
 
 type 'a result = Success of string * 'a | Failure of string * exn
 
+let temp_dir = "/var/run/nonpersistent/forkexecd/"
+
 (** Creates a temporary file and opens it for logging. The fd is passed to the function
     'f'. The logfile is guaranteed to be closed afterwards, and unlinked if either the delete flag is set or the call fails. If the
     function 'f' throws an error then the log file contents are read in *)
-let with_logfile_fd ?(delete = true) prefix f = 
-  let logfile = Filename.temp_file prefix ".log" in
+let with_logfile_fd ?(delete = true) prefix f =
+  let logfile = Filename.temp_file ~temp_dir prefix ".log" in
   let read_logfile () = 
     let contents = Xapi_stdext_unix.Unixext.string_of_file logfile in
     Unix.unlink logfile;

--- a/lib/forkhelpers.mli
+++ b/lib/forkhelpers.mli
@@ -104,5 +104,7 @@ type 'a result =
     function [f] throws an error then the log file contents are read in *)
 val with_logfile_fd : ?delete:bool -> string -> (Unix.file_descr -> 'a) -> 'a result
 
+(** Temporary directory used for communication *)
+val temp_dir: string
 
 

--- a/src/fe_main.ml
+++ b/src/fe_main.ml
@@ -1,7 +1,7 @@
 open Fe_debug
 
 let setup sock cmdargs id_to_fd_map syslog_stdout redirect_stderr_to_stdout env =
-  let fd_sock_path = Printf.sprintf "/var/xapi/forker/fd_%s" 
+  let fd_sock_path = Printf.sprintf "%s/fd_%s" Forkhelpers.temp_dir
       (Uuidm.to_string (Uuidm.create `V4)) in
   let fd_sock = Fecomms.open_unix_domain_sock () in
   Xapi_stdext_unix.Unixext.unlink_safe fd_sock_path;
@@ -44,6 +44,7 @@ let _ =
   Sys.set_signal Sys.sigpipe (Sys.Signal_ignore);
 
   let main_sock = Fecomms.open_unix_domain_sock_server "/var/xapi/forker/main" in
+  Xapi_stdext_unix.Unixext.mkdir_rec (Forkhelpers.temp_dir) 0o755;
 
   Daemon.notify Daemon.State.Ready |> ignore;
 


### PR DESCRIPTION
This creates them in memory avoiding frequent disk writes.