### PR TITLE
opam: use ppx_deriving_rpc

### DIFF
--- a/forkexec.opam
+++ b/forkexec.opam
@@ -13,6 +13,7 @@ depends: [
   "dune" {build}
   "base-threads"
   "fd-send-recv"
+  "ppx_deriving_rpc"
   "rpclib"
   "uuidm"
   "xapi-idl"


### PR DESCRIPTION
Right now compilation works because the dependency is being pulled in by xcp-idl, better not bank on that.