### PR TITLE
CP-33121: remove stdext's monadic and range usages

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,9 @@
+profile=ocamlformat
+version=0.14.1
+indicate-multiline-delimiters=closing-on-separate-line
+if-then-else=fit-or-vertical
+dock-collection-brackets=true
+break-struct=natural
+break-separators=before
+break-infix=fit-or-vertical
+break-infix-before-func=false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: release build install uninstall clean test doc reindent
+.PHONY: release build install uninstall clean test doc format
 
 release:
 	dune build @install --profile=release
@@ -26,5 +26,5 @@ test:
 doc:
 	dune build @doc --profile=release
 
-reindent:
-	git ls-files '*.ml*' | xargs ocp-indent --inplace
+format:
+	dune build @fmt --auto-promote

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
-(lang dune 1.4)
+(lang dune 1.11)
+(using fmt 1.2 (enabled_for ocaml))

--- a/forkexec.opam
+++ b/forkexec.opam
@@ -17,7 +17,6 @@ depends: [
   "rpclib"
   "uuidm"
   "xapi-idl"
-  "xapi-stdext-monadic"
   "xapi-stdext-pervasives"
   "xapi-stdext-unix"
 ]

--- a/lib/dune
+++ b/lib/dune
@@ -8,7 +8,6 @@
     rpclib.json
     threads
     uuidm
-    xapi-stdext-monadic
     xapi-stdext-pervasives
     xapi-stdext-unix
     xapi-idl

--- a/lib/fe_argv.mli
+++ b/lib/fe_argv.mli
@@ -28,7 +28,9 @@ val (>>=):   'a t -> ('a -> 'b t) -> 'b t
  * we are interested in. These can be accessed using [argv] and [fd_map].
  *)
 val run:    'a t -> 'a * argv
-val argv:   argv -> string list                     (** argument list *)
+val argv:   argv -> string list
+(** argument list *)
+
 val fd_map: argv -> (string * Unix.file_descr) list (** file descriptors *)
 
 (** functions to build argument vector incrementally *)

--- a/lib/fecomms.ml
+++ b/lib/fecomms.ml
@@ -1,4 +1,4 @@
-open Xapi_stdext_unix
+module Unixext = Xapi_stdext_unix.Unixext
 open Fe
 
 let open_unix_domain_sock () =

--- a/lib/forkhelpers.ml
+++ b/lib/forkhelpers.ml
@@ -184,16 +184,15 @@ let execute_command_get_output_inner ?env ?stdin ?(syslog_stdout=NoSyslogging) ?
       Unix.close fd;
       to_close := List.filter (fun x -> x <> fd) !to_close;
     end in
-  let open Xapi_stdext_monadic in
-  let stdinandpipes = Opt.map (fun str -> 
+  let stdinandpipes = Option.map (fun str ->
       let (x,y) = Unix.pipe () in
       to_close := x :: y :: !to_close;
       (str,x,y)) stdin in
   finally (fun () -> 
       match with_logfile_fd "execute_command_get_out" (fun out_fd ->
           with_logfile_fd "execute_command_get_err" (fun err_fd ->
-              let (sock,pid) = safe_close_and_exec ?env (Opt.map (fun (_,fd,_) -> fd) stdinandpipes) (Some out_fd) (Some err_fd) [] ~syslog_stdout cmd args in
-              Opt.iter (fun (str,_,wr) ->
+              let (sock,pid) = safe_close_and_exec ?env (Option.map (fun (_,fd,_) -> fd) stdinandpipes) (Some out_fd) (Some err_fd) [] ~syslog_stdout cmd args in
+              Option.iter (fun (str,_,wr) ->
                   Xapi_stdext_unix.Unixext.really_write_string wr str;
                   close wr;
                 ) stdinandpipes;

--- a/lib/forkhelpers.ml
+++ b/lib/forkhelpers.ml
@@ -23,7 +23,7 @@
 
 let default_path = [ "/sbin"; "/usr/sbin"; "/bin"; "/usr/bin" ]
 
-open Xapi_stdext_pervasives.Pervasiveext
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 type pidty = (Unix.file_descr * int) (* The forking executioner has been used, therefore we need to tell *it* to waitpid *)
 

--- a/src/child.ml
+++ b/src/child.ml
@@ -98,7 +98,7 @@ let log_failure args child_pid reason =
   Fe_debug.error "%d (%s) %s" child_pid cmdline' reason
 
 let report_child_exit comms_sock args child_pid status =
-  let open Xapi_stdext_unix in
+  let module Unixext = Xapi_stdext_unix.Unixext in
   let pr = match status with
     | Unix.WEXITED n ->
       (* Unfortunately logging this was causing too much spam *)

--- a/src/child.ml
+++ b/src/child.ml
@@ -184,14 +184,13 @@ let run state comms_sock fd_sock fd_sock_path =
 
     let result = Unix.fork () in
 
-    let open Xapi_stdext_monadic in
     if result=0 then begin
       (* child *)
 
       (* Make the child's stdout go into the pipe *)
-      Opt.iter (fun out_fd -> Unix.dup2 out_fd Unix.stdout) !out_childlogging;
+      Option.iter (fun out_fd -> Unix.dup2 out_fd Unix.stdout) !out_childlogging;
       if state.redirect_stderr_to_stdout then
-        Opt.iter (fun out_fd -> Unix.dup2 out_fd Unix.stderr) !out_childlogging;
+        Option.iter (fun out_fd -> Unix.dup2 out_fd Unix.stderr) !out_childlogging;
 
       (* Now let's close everything except those fds mentioned in the ids_received list *)
       Xapi_stdext_unix.Unixext.close_all_fds_except ([Unix.stdin; Unix.stdout; Unix.stderr] @ fds);
@@ -223,9 +222,9 @@ let run state comms_sock fd_sock fd_sock_path =
       List.iter (fun fd -> Unix.close fd) fds;
 
       (* Close the end of the pipe that's only supposed to be written to by the child process. *)
-      Opt.iter Unix.close !out_childlogging;
+      Option.iter Unix.close !out_childlogging;
 
-      Opt.iter
+      Option.iter
         (fun in_fd ->
            let key = (match state.syslog_stdout.key with None -> Filename.basename name | Some key -> key) in
            (* Read from the child's stdout and write each one to syslog *)

--- a/src/dune
+++ b/src/dune
@@ -7,7 +7,6 @@
     forkexec
     systemd
     uuidm
-    xapi-stdext-monadic
     xapi-stdext-unix
   )
 )

--- a/test/dune
+++ b/test/dune
@@ -3,7 +3,6 @@
   (libraries
     forkexec
     uuidm
-    xapi-stdext-range
     xapi-stdext-unix
   )
 )

--- a/xapi-forkexecd.opam
+++ b/xapi-forkexecd.opam
@@ -17,7 +17,6 @@ depends: [
   "forkexec"
   "systemd" {>= "1.2"}
   "uuidm"
-  "xapi-stdext-monadic"
   "xapi-stdext-unix"
   "xapi-stdext-range" {with-test}
 ]

--- a/xapi-forkexecd.opam
+++ b/xapi-forkexecd.opam
@@ -18,7 +18,6 @@ depends: [
   "systemd" {>= "1.2"}
   "uuidm"
   "xapi-stdext-unix"
-  "xapi-stdext-range" {with-test}
 ]
 conflicts: [
   "fd-send-recv" {< "2.0.0"}


### PR DESCRIPTION
I've also included the configuration to use ocamlformat so we can format code when we deem necessary.