### PR TITLE
CP-34942: Make test compatible with dune 2.7+

### DIFF
--- a/test/fe_test.sh
+++ b/test/fe_test.sh
@@ -15,4 +15,4 @@ trap cleanup EXIT
 for _ in $(seq 1 10); do
     test -S ${SOCKET} || sleep 1
 done
-./fe_test.exe 16
+echo "" | ./fe_test.exe 16


### PR DESCRIPTION
Newer versions of dune force a null stdin in the tests, which breaks
them. Pipe the output of echo to force the test binary use anything
other than /dev/null for stdin.

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>