### PR TITLE
CP-34942: Make test compatible with dune 2.7+

### DIFF
--- a/test/fe_test.sh
+++ b/test/fe_test.sh
@@ -9,4 +9,4 @@ trap cleanup EXIT
 for _ in $(seq 1 10); do
 	test -S /var/xapi/forker/main || sleep 1
 done
-./fe_test.exe 16
+echo "" | ./fe_test.exe 16


### PR DESCRIPTION
Newer versions of dune force a null stdin in the tests, which breaks
them. Pipe the output of echo to force the test binary use anything
other than /dev/null for stdin.

Cherry-picked from 1dbfb24a54fa6aaf0a71aa2da47d4294e1f9c7d5

tests passing can be observed in https://github.com/xapi-project/xs-opam/runs/7859363385?check_suite_focus=true