### PR TITLE
Revert "CA-341921: avoid EINVAL errors for >1024 FDs"

### DIFF
--- a/lib/forkhelpers.ml
+++ b/lib/forkhelpers.ml
@@ -44,14 +44,9 @@ let waitpid (sock, pid) =
   end
 
 let waitpid_nohang ((sock, _) as x) =
-  Unix.set_nonblock sock;
-  let r =
-    try waitpid x
-    with Unix.(Unix_error((EAGAIN|EWOULDBLOCK), _, _)) ->
-      (0,Unix.WEXITED 0)
-  in
-  Unix.clear_nonblock sock;
-  r
+  (match Unix.select [sock] [] [] 0.0 with
+   | ([_s],_,_) -> waitpid x
+   | _ -> (0,Unix.WEXITED 0))
 
 let dontwaitpid (sock, _pid) =
   begin
@@ -202,10 +197,9 @@ let execute_command_get_output_inner ?env ?stdin ?(syslog_stdout=NoSyslogging) ?
                   Xapi_stdext_unix.Unixext.really_write_string wr str;
                   close wr;
                 ) stdinandpipes;
-              if timeout > 0. then
-                Unix.setsockopt_float sock Unix.SO_RCVTIMEO timeout;
-              try waitpid (sock, pid)
-              with Unix.(Unix_error((EAGAIN|EWOULDBLOCK), _, _)) ->
+              match Unix.select [sock] [] [] timeout with
+              | ([_s],_,_) -> waitpid (sock,pid)
+              | _ ->
                 Unix.kill pid Sys.sigkill;
                 ignore (waitpid (sock,pid));
                 raise Subprocess_timeout


### PR DESCRIPTION
This reverts commit 846e6fbff7abd27ac14dc4649da55d5ad05d6acb.

This commit introduces a new problem: CA-378317.